### PR TITLE
jが入っていないときに行が消える

### DIFF
--- a/autoload/jplus.vim
+++ b/autoload/jplus.vim
@@ -49,7 +49,7 @@ function! s:add_comment_leader_pattern(current_pattern)
 
   " Note: a:current_pattern MUST come at the end since it might contain '.*'
   " in the pattern, which will match even the comment leaders
-  return '\(' . join(to_consider, '\|') . '\|' . a:current_pattern . '\)'
+  return '\%(' . join(to_consider, '\|') . '\|' . a:current_pattern . '\)'
 endfunction
 
 

--- a/autoload/jplus.vim
+++ b/autoload/jplus.vim
@@ -30,7 +30,7 @@ endfunction
 
 function! s:add_comment_leader_pattern(current_pattern)
   if &formatoptions !~ 'j'
-    return
+    return a:current_pattern
   endif
 
   let flags = '\(^:\|m\)'


### PR DESCRIPTION
すみません！
`formatoptions`に`j`がない場合の動作をテストしたと思っていたのですが、つもりになっていただけだったようです。お恥ずかしい。