### PR TITLE
Move cursor to the column where last join occurred

### DIFF
--- a/autoload/jplus.vim
+++ b/autoload/jplus.vim
@@ -86,6 +86,8 @@ function! s:join(config)
 	let line = s:join_list(getline(start, end), c, ignore, left_matchstr, right_matchstr)
 
 	let view = winsaveview()
+	let new_col = len(line) - len(matchstr(getline(end), right_matchstr))
+	let view['col'] = new_col - 1
 	call setline(start, line)
 
 	if start+1 <= end


### PR DESCRIPTION
デフォルトのJの挙動に従い、

```ruby
hoge =_'huga' \
  'huga'
```

とあった場合、(`_`がカーソル位置)

```ruby
hoge = 'huga'_'huga'
```

となるようにしました。